### PR TITLE
Fix address-of-packed-member warnings

### DIFF
--- a/grub-core/commands/usbtest.c
+++ b/grub-core/commands/usbtest.c
@@ -69,6 +69,7 @@ grub_usb_get_string (grub_usb_device_t dev, grub_uint8_t index, int langid,
 {
   struct grub_usb_desc_str descstr;
   struct grub_usb_desc_str *descstrp;
+  grub_uint16_t *strbuf;
   grub_usb_err_t err;
 
   /* Only get the length.  */
@@ -101,8 +102,18 @@ grub_usb_get_string (grub_usb_device_t dev, grub_uint8_t index, int langid,
       return GRUB_USB_ERR_INTERNAL;
     }
 
-  *grub_utf16_to_utf8 ((grub_uint8_t *) *string, descstrp->str,
+  strbuf = grub_malloc (descstrp->length - sizeof (*descstrp));
+  if (!strbuf)
+    {
+      grub_free (*string);
+      grub_free (descstrp);
+      return GRUB_USB_ERR_INTERNAL;
+    }
+
+  grub_memcpy (strbuf, descstrp->str, descstrp->length - sizeof (*descstrp));
+  *grub_utf16_to_utf8 ((grub_uint8_t *) *string, strbuf,
                       descstrp->length / 2 - 1) = 0;
+  grub_free (strbuf);
   grub_free (descstrp);
 
   return GRUB_USB_ERR_NONE;

--- a/grub-core/commands/usbtest.c
+++ b/grub-core/commands/usbtest.c
@@ -102,7 +102,7 @@ grub_usb_get_string (grub_usb_device_t dev, grub_uint8_t index, int langid,
     }
 
   *grub_utf16_to_utf8 ((grub_uint8_t *) *string, descstrp->str,
-		       descstrp->length / 2 - 1) = 0;
+                      descstrp->length / 2 - 1) = 0;
   grub_free (descstrp);
 
   return GRUB_USB_ERR_NONE;

--- a/grub-core/fs/btrfs.c
+++ b/grub-core/fs/btrfs.c
@@ -175,7 +175,7 @@ struct grub_btrfs_time
 {
   grub_int64_t sec;
   grub_uint32_t nanosec;
-} __attribute__ ((aligned (4)));
+} GRUB_PACKED;
 
 struct grub_btrfs_inode
 {

--- a/grub-core/fs/cpio.c
+++ b/grub-core/fs/cpio.c
@@ -38,11 +38,12 @@ struct head
 } GRUB_PACKED;
 
 static inline unsigned long long
-read_number (const grub_uint16_t *arr, grub_size_t size)
+read_number (const void *arr, grub_size_t size)
 {
   long long ret = 0;
+  const grub_uint16_t *p = (const grub_uint16_t *)arr;
   while (size--)
-    ret = (ret << 16) | grub_le_to_cpu16 (*arr++);
+    ret = (ret << 16) | grub_le_to_cpu16 (grub_get_unaligned16 (p++));
   return ret;
 }
 

--- a/grub-core/fs/cpio_be.c
+++ b/grub-core/fs/cpio_be.c
@@ -38,11 +38,12 @@ struct head
 } GRUB_PACKED;
 
 static inline unsigned long long
-read_number (const grub_uint16_t *arr, grub_size_t size)
+read_number (const void *arr, grub_size_t size)
 {
   long long ret = 0;
+  const grub_uint16_t *p = (const grub_uint16_t *)arr;
   while (size--)
-    ret = (ret << 16) | grub_be_to_cpu16 (*arr++);
+    ret = (ret << 16) | grub_be_to_cpu16 (grub_get_unaligned16 (p++));
   return ret;
 }
 

--- a/grub-core/fs/hfsplus.c
+++ b/grub-core/fs/hfsplus.c
@@ -19,7 +19,7 @@
 
 /* HFS+ is documented at http://developer.apple.com/technotes/tn/tn1150.html */
 
-#define grub_fshelp_node grub_hfsplus_file 
+#define grub_fshelp_node grub_hfsplus_file
 #include <grub/err.h>
 #include <grub/file.h>
 #include <grub/mm.h>
@@ -145,7 +145,7 @@ grub_hfsplus_read_block (grub_fshelp_node_t node, grub_disk_addr_t fileblock)
 {
   struct grub_hfsplus_btnode *nnode = 0;
   grub_disk_addr_t blksleft = fileblock;
-  struct grub_hfsplus_extent *extents = node->compressed 
+  struct grub_hfsplus_extent *extents = node->compressed
     ? &node->resource_extents[0] : &node->extents[0];
 
   while (1)
@@ -461,7 +461,7 @@ grub_hfsplus_cmp_extkey (struct grub_hfsplus_key *keya,
 
   if (extkey_a->type < extkey_b->type)
     return -1;
-  
+
   akey = grub_be_to_cpu32 (extkey_a->start);
   if (akey > extkey_b->start)
     return 1;
@@ -548,7 +548,7 @@ grub_hfsplus_btree_search (struct grub_hfsplus_btree *btree,
 			   struct grub_hfsplus_key_internal *key,
 			   int (*compare_keys) (struct grub_hfsplus_key *keya,
 						struct grub_hfsplus_key_internal *keyb),
-			   struct grub_hfsplus_btnode **matchnode, 
+			   struct grub_hfsplus_btnode **matchnode,
 			   grub_off_t *keyoffset)
 {
   grub_uint64_t currnode;
@@ -725,24 +725,24 @@ list_nodes (void *record, void *hook_arg)
       catkey->name[i] = grub_be_to_cpu16 (catkey->name[i]);
 
       if (catkey->name[i] == '/')
-	catkey->name[i] = ':';
+       catkey->name[i] = ':';
 
       /* If the name is obviously invalid, skip this node.  */
       if (catkey->name[i] == 0)
-	{
-	  grub_free (filename);
-	  return 0;
-	}
+       {
+         grub_free (filename);
+         return 0;
+       }
     }
 
   *grub_utf16_to_utf8 ((grub_uint8_t *) filename, catkey->name,
-		       grub_be_to_cpu16 (catkey->namelen)) = '\0';
+                      grub_be_to_cpu16 (catkey->namelen)) = '\0';
 
   /* Restore the byte order to what it was previously.  */
   for (i = 0; i < grub_be_to_cpu16 (catkey->namelen); i++)
     {
       if (catkey->name[i] == ':')
-	catkey->name[i] = '/';
+       catkey->name[i] = '/';
       catkey->name[i] = grub_be_to_cpu16 (catkey->name[i]);
     }
 
@@ -1009,7 +1009,7 @@ grub_hfsplus_label (grub_device_t device, char **label)
 
       /* If the name is obviously invalid, skip this node.  */
       if (catkey->name[i] == 0)
-	return 0;
+       return 0;
     }
 
   *label = grub_malloc (label_len * GRUB_MAX_UTF8_PER_UTF16 + 1);
@@ -1017,7 +1017,7 @@ grub_hfsplus_label (grub_device_t device, char **label)
     return grub_errno;
 
   *grub_utf16_to_utf8 ((grub_uint8_t *) (*label), catkey->name,
-		       label_len) = '\0';
+                      label_len) = '\0';
 
   grub_free (node);
   grub_free (data);

--- a/grub-core/fs/hfsplus.c
+++ b/grub-core/fs/hfsplus.c
@@ -661,6 +661,7 @@ list_nodes (void *record, void *hook_arg)
   char *filename;
   int i;
   struct grub_fshelp_node *node;
+  grub_uint16_t *keyname;
   struct grub_hfsplus_catfile *fileinfo;
   enum grub_fshelp_filetype type = GRUB_FSHELP_UNKNOWN;
   struct list_nodes_ctx *ctx = hook_arg;
@@ -719,32 +720,34 @@ list_nodes (void *record, void *hook_arg)
   if (! filename)
     return 0;
 
+  keyname = grub_malloc (grub_be_to_cpu16 (catkey->namelen) * sizeof (*keyname));
+  if (!keyname)
+    {
+      grub_free (filename);
+      return 0;
+    }
+
   /* Make sure the byte order of the UTF16 string is correct.  */
   for (i = 0; i < grub_be_to_cpu16 (catkey->namelen); i++)
     {
-      catkey->name[i] = grub_be_to_cpu16 (catkey->name[i]);
+      keyname[i] = grub_be_to_cpu16 (catkey->name[i]);
 
-      if (catkey->name[i] == '/')
-       catkey->name[i] = ':';
+      if (keyname[i] == '/')
+       keyname[i] = ':';
 
       /* If the name is obviously invalid, skip this node.  */
-      if (catkey->name[i] == 0)
+      if (keyname[i] == 0)
        {
+         grub_free (keyname);
          grub_free (filename);
          return 0;
        }
     }
 
-  *grub_utf16_to_utf8 ((grub_uint8_t *) filename, catkey->name,
+  *grub_utf16_to_utf8 ((grub_uint8_t *) filename, keyname,
                       grub_be_to_cpu16 (catkey->namelen)) = '\0';
 
-  /* Restore the byte order to what it was previously.  */
-  for (i = 0; i < grub_be_to_cpu16 (catkey->namelen); i++)
-    {
-      if (catkey->name[i] == ':')
-       catkey->name[i] = '/';
-      catkey->name[i] = grub_be_to_cpu16 (catkey->name[i]);
-    }
+  grub_free (keyname);
 
   /* hfs+ is case insensitive.  */
   if (! ctx->dir->data->case_sensitive)
@@ -975,6 +978,7 @@ grub_hfsplus_label (grub_device_t device, char **label)
   grub_disk_t disk = device->disk;
   struct grub_hfsplus_catkey *catkey;
   int i, label_len;
+  grub_uint16_t *label_name;
   struct grub_hfsplus_key_internal intern;
   struct grub_hfsplus_btnode *node = NULL;
   grub_disk_addr_t ptr = 0;
@@ -1003,22 +1007,41 @@ grub_hfsplus_label (grub_device_t device, char **label)
     grub_hfsplus_btree_recptr (&data->catalog_tree, node, ptr);
 
   label_len = grub_be_to_cpu16 (catkey->namelen);
+  label_name = grub_malloc (label_len * sizeof (*label_name));
+  if (!label_name)
+    {
+      grub_free (node);
+      grub_free (data);
+      return grub_errno;
+    }
+
   for (i = 0; i < label_len; i++)
     {
-      catkey->name[i] = grub_be_to_cpu16 (catkey->name[i]);
+      label_name[i] = grub_be_to_cpu16 (catkey->name[i]);
 
       /* If the name is obviously invalid, skip this node.  */
-      if (catkey->name[i] == 0)
-       return 0;
+      if (label_name[i] == 0)
+       {
+         grub_free (label_name);
+         grub_free (node);
+         grub_free (data);
+         return 0;
+       }
     }
 
   *label = grub_malloc (label_len * GRUB_MAX_UTF8_PER_UTF16 + 1);
   if (! *label)
-    return grub_errno;
+    {
+      grub_free (label_name);
+      grub_free (node);
+      grub_free (data);
+      return grub_errno;
+    }
 
-  *grub_utf16_to_utf8 ((grub_uint8_t *) (*label), catkey->name,
+  *grub_utf16_to_utf8 ((grub_uint8_t *) (*label), label_name,
                       label_len) = '\0';
 
+  grub_free (label_name);
   grub_free (node);
   grub_free (data);
 

--- a/grub-core/fs/jfs.c
+++ b/grub-core/fs/jfs.c
@@ -499,10 +499,11 @@ grub_jfs_closedir (struct grub_jfs_diropen *diro)
 }
 
 static void
-le_to_cpu16_copy (grub_uint16_t *out, grub_uint16_t *in, grub_size_t len)
+le_to_cpu16_copy (grub_uint16_t *out, const void *in, grub_size_t len)
 {
+  const grub_uint16_t *p = (const grub_uint16_t *)in;
   while (len--)
-    *out++ = grub_le_to_cpu16 (*in++);
+    *out++ = grub_le_to_cpu16 (grub_get_unaligned16 (p++));
 }
 
 

--- a/grub-core/kern/efi/efi.c
+++ b/grub-core/kern/efi/efi.c
@@ -201,7 +201,7 @@ grub_efi_set_variable(const char *var, const grub_efi_guid_t *guid,
 
   r = grub_efi_system_table->runtime_services;
 
-  status = efi_call_5 (r->set_variable, var16, guid, 
+  status = efi_call_5 (r->set_variable, var16, guid,
 		       (GRUB_EFI_VARIABLE_NON_VOLATILE
 			| GRUB_EFI_VARIABLE_BOOTSERVICE_ACCESS
 			| GRUB_EFI_VARIABLE_RUNTIME_ACCESS),
@@ -357,21 +357,21 @@ grub_efi_get_filename (grub_efi_device_path_t *dp0)
 	break;
       else if (type == GRUB_EFI_MEDIA_DEVICE_PATH_TYPE
 	       && subtype == GRUB_EFI_FILE_PATH_DEVICE_PATH_SUBTYPE)
-	{
-	  grub_efi_file_path_device_path_t *fp;
-	  grub_efi_uint16_t len;
+       {
+         grub_efi_file_path_device_path_t *fp;
+         grub_efi_uint16_t len;
 
-	  *p++ = '/';
+         *p++ = '/';
 
 	  len = ((GRUB_EFI_DEVICE_PATH_LENGTH (dp) - 4)
 		 / sizeof (grub_efi_char16_t));
 	  fp = (grub_efi_file_path_device_path_t *) dp;
 	  /* According to EFI spec Path Name is NULL terminated */
-	  while (len > 0 && fp->path_name[len - 1] == 0)
-	    len--;
+         while (len > 0 && fp->path_name[len - 1] == 0)
+           len--;
 
-	  p = (char *) grub_utf16_to_utf8 ((unsigned char *) p, fp->path_name, len);
-	}
+         p = (char *) grub_utf16_to_utf8 ((unsigned char *) p, fp->path_name, len);
+       }
 
       dp = GRUB_EFI_NEXT_DEVICE_PATH (dp);
     }
@@ -797,15 +797,15 @@ grub_efi_print_device_path (grub_efi_device_path_t *dp)
 	      {
 		grub_efi_file_path_device_path_t *fp;
 		grub_uint8_t *buf;
-		fp = (grub_efi_file_path_device_path_t *) dp;
-		buf = grub_malloc ((len - 4) * 2 + 1);
-		if (buf)
-		  *grub_utf16_to_utf8 (buf, fp->path_name,
-				       (len - 4) / sizeof (grub_efi_char16_t))
-		    = '\0';
-		else
-		  grub_errno = GRUB_ERR_NONE;
-		grub_printf ("/File(%s)", buf);
+               fp = (grub_efi_file_path_device_path_t *) dp;
+               buf = grub_malloc ((len - 4) * 2 + 1);
+               if (buf)
+                 *grub_utf16_to_utf8 (buf, fp->path_name,
+                                      (len - 4) / sizeof (grub_efi_char16_t))
+                   = '\0';
+               else
+                 grub_errno = GRUB_ERR_NONE;
+               grub_printf ("/File(%s)", buf);
 		grub_free (buf);
 	      }
 	      break;

--- a/grub-core/kern/efi/efi.c
+++ b/grub-core/kern/efi/efi.c
@@ -360,6 +360,7 @@ grub_efi_get_filename (grub_efi_device_path_t *dp0)
        {
          grub_efi_file_path_device_path_t *fp;
          grub_efi_uint16_t len;
+         grub_efi_char16_t *dup_name;
 
          *p++ = '/';
 
@@ -370,7 +371,16 @@ grub_efi_get_filename (grub_efi_device_path_t *dp0)
          while (len > 0 && fp->path_name[len - 1] == 0)
            len--;
 
-         p = (char *) grub_utf16_to_utf8 ((unsigned char *) p, fp->path_name, len);
+         dup_name = grub_malloc (len * sizeof (*dup_name));
+         if (!dup_name)
+           {
+             grub_free (name);
+             return NULL;
+           }
+         p = (char *) grub_utf16_to_utf8 ((unsigned char *) p,
+                                           grub_memcpy (dup_name, fp->path_name, len * sizeof (*dup_name)),
+                                           len);
+         grub_free (dup_name);
        }
 
       dp = GRUB_EFI_NEXT_DEVICE_PATH (dp);
@@ -800,9 +810,20 @@ grub_efi_print_device_path (grub_efi_device_path_t *dp)
                fp = (grub_efi_file_path_device_path_t *) dp;
                buf = grub_malloc ((len - 4) * 2 + 1);
                if (buf)
-                 *grub_utf16_to_utf8 (buf, fp->path_name,
+                 {
+                   grub_efi_char16_t *dup_name = grub_malloc (len - 4);
+                   if (!dup_name)
+                     {
+                       grub_errno = GRUB_ERR_NONE;
+                       grub_printf ("/File((null))");
+                       grub_free (buf);
+                       break;
+                     }
+                   *grub_utf16_to_utf8 (buf, grub_memcpy (dup_name, fp->path_name, len - 4),
                                       (len - 4) / sizeof (grub_efi_char16_t))
-                   = '\0';
+                     = '\0';
+                   grub_free (dup_name);
+                 }
                else
                  grub_errno = GRUB_ERR_NONE;
                grub_printf ("/File(%s)", buf);

--- a/grub-core/loader/efi/chainloader.c
+++ b/grub-core/loader/efi/chainloader.c
@@ -108,7 +108,7 @@ grub_chainloader_boot (void)
 
 static void
 copy_file_path (grub_efi_file_path_device_path_t *fp,
-		const char *str, grub_efi_uint16_t len)
+               const char *str, grub_efi_uint16_t len)
 {
   grub_efi_char16_t *p;
   grub_efi_uint16_t size;
@@ -117,7 +117,7 @@ copy_file_path (grub_efi_file_path_device_path_t *fp,
   fp->header.subtype = GRUB_EFI_FILE_PATH_DEVICE_PATH_SUBTYPE;
 
   size = grub_utf8_to_utf16 (fp->path_name, len * GRUB_MAX_UTF16_PER_UTF8,
-			     (const grub_uint8_t *) str, len, 0);
+                            (const grub_uint8_t *) str, len, 0);
   for (p = fp->path_name; p < fp->path_name + size; p++)
     if (*p == '/')
       *p = '\\';

--- a/grub-core/loader/efi/chainloader.c
+++ b/grub-core/loader/efi/chainloader.c
@@ -110,21 +110,27 @@ static void
 copy_file_path (grub_efi_file_path_device_path_t *fp,
                const char *str, grub_efi_uint16_t len)
 {
-  grub_efi_char16_t *p;
+  grub_efi_char16_t *p, *path_name;
   grub_efi_uint16_t size;
 
   fp->header.type = GRUB_EFI_MEDIA_DEVICE_PATH_TYPE;
   fp->header.subtype = GRUB_EFI_FILE_PATH_DEVICE_PATH_SUBTYPE;
 
-  size = grub_utf8_to_utf16 (fp->path_name, len * GRUB_MAX_UTF16_PER_UTF8,
+  path_name = grub_malloc (len * GRUB_MAX_UTF16_PER_UTF8 * sizeof (*path_name));
+  if (!path_name)
+    return;
+
+  size = grub_utf8_to_utf16 (path_name, len * GRUB_MAX_UTF16_PER_UTF8,
                             (const grub_uint8_t *) str, len, 0);
-  for (p = fp->path_name; p < fp->path_name + size; p++)
+  for (p = path_name; p < path_name + size; p++)
     if (*p == '/')
       *p = '\\';
 
+  grub_memcpy (fp->path_name, path_name, size * sizeof (*fp->path_name));
   /* File Path is NULL terminated */
   fp->path_name[size++] = '\0';
   fp->header.length = size * sizeof (grub_efi_char16_t) + sizeof (*fp);
+  grub_free (path_name);
 }
 
 static grub_efi_device_path_t *

--- a/include/grub/acpi.h
+++ b/include/grub/acpi.h
@@ -93,7 +93,7 @@ struct grub_acpi_madt
   grub_uint32_t lapic_addr;
   grub_uint32_t flags;
   struct grub_acpi_madt_entry_header entries[0];
-};
+} GRUB_PACKED;
 
 enum
   {

--- a/include/grub/efiemu/runtime.h
+++ b/include/grub/efiemu/runtime.h
@@ -29,7 +29,7 @@ struct grub_efiemu_ptv_rel
 
 struct efi_variable
 {
-  grub_efi_guid_t guid;
+  grub_efi_packed_guid_t guid;
   grub_uint32_t namelen;
   grub_uint32_t size;
   grub_efi_uint32_t attributes;

--- a/include/grub/gpt_partition.h
+++ b/include/grub/gpt_partition.h
@@ -28,7 +28,7 @@ struct grub_gpt_part_type
   grub_uint16_t data2;
   grub_uint16_t data3;
   grub_uint8_t data4[8];
-} __attribute__ ((aligned(8)));
+} GRUB_PACKED;
 typedef struct grub_gpt_part_type grub_gpt_part_type_t;
 
 #define GRUB_GPT_PARTITION_TYPE_EMPTY \

--- a/include/grub/hfs.h
+++ b/include/grub/hfs.h
@@ -29,7 +29,7 @@ struct grub_hfs_extent
   /* The first physical block.  */
   grub_uint16_t first_block;
   grub_uint16_t count;
-};
+} GRUB_PACKED;
 
 /* HFS stores extents in groups of 3.  */
 typedef struct grub_hfs_extent grub_hfs_datarecord_t[3];


### PR DESCRIPTION
Fixes new compilation warnings (which are upgraded to errors) in GCC8 and above.